### PR TITLE
Add model reinitialize endpoint

### DIFF
--- a/api/src/inference/kokoro_v1.py
+++ b/api/src/inference/kokoro_v1.py
@@ -61,7 +61,7 @@ class KokoroV1(BaseModelBackend):
                 self._model = self._model.cpu()
 
         except FileNotFoundError as e:
-            raise e
+            raise RuntimeError(f"Failed to load Kokoro model: {e}") from e
         except Exception as e:
             raise RuntimeError(f"Failed to load Kokoro model: {e}")
 

--- a/api/tests/test_debug_reinitialize.py
+++ b/api/tests/test_debug_reinitialize.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.src.main import app
+
+client = TestClient(app)
+
+
+def test_reinitialize_endpoint():
+    model_manager = AsyncMock()
+    voice_manager = AsyncMock()
+    model_manager.initialize_with_warmup.return_value = ("cpu", "kokoro_v1", 1)
+
+    with (
+        patch(
+            "api.src.inference.model_manager.get_manager",
+            AsyncMock(return_value=model_manager),
+        ),
+        patch(
+            "api.src.inference.voice_manager.get_manager",
+            AsyncMock(return_value=voice_manager),
+        ),
+    ):
+        response = client.post("/debug/reinitialize")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "device": "cpu",
+        "model": "kokoro_v1",
+        "voice_packs": 1,
+    }
+    model_manager.unload_all.assert_called_once()
+    model_manager.initialize_with_warmup.assert_called_once_with(voice_manager)

--- a/api/tests/test_debug_set_voice.py
+++ b/api/tests/test_debug_set_voice.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.src.main import app
+
+client = TestClient(app)
+
+
+def test_set_default_voice():
+    voice_manager = AsyncMock()
+    voice_manager.list_voices.return_value = ["voice1", "voice2"]
+
+    with (
+        patch(
+            "api.src.routers.debug.get_voice_manager",
+            AsyncMock(return_value=voice_manager),
+        ),
+        patch("api.src.routers.debug.settings") as mock_settings,
+    ):
+        mock_settings.default_voice = "voice1"
+        response = client.post("/debug/voice", json={"voice": "voice2"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "voice": "voice2"}
+    assert mock_settings.default_voice == "voice2"
+    assert mock_settings.default_voice_code == "v"
+
+
+def test_set_default_voice_invalid():
+    voice_manager = AsyncMock()
+    voice_manager.list_voices.return_value = ["voice1", "voice2"]
+
+    with (
+        patch(
+            "api.src.routers.debug.get_voice_manager",
+            AsyncMock(return_value=voice_manager),
+        ),
+        patch("api.src.routers.debug.settings"),
+    ):
+        response = client.post("/debug/voice", json={"voice": "unknown"})
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["detail"]["error"] == "voice_not_found"


### PR DESCRIPTION
## Summary
- add `/debug/reinitialize` POST endpoint to reload KokoroV1
- add `/debug/voice` endpoint for switching default voice
- test coverage for the new endpoints
- ensure load_model always raises `RuntimeError`

## Testing
- `ruff format api/src/routers/debug.py api/tests/test_debug_set_voice.py api/tests/test_debug_reinitialize.py`
- `ruff check api/src/routers/debug.py api/tests/test_debug_set_voice.py api/tests/test_debug_reinitialize.py --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_b_684fe54ca4148322aae683540fe59dc3