### PR TITLE
Add dev endpoints for speech config

### DIFF
--- a/api/src/routers/development.py
+++ b/api/src/routers/development.py
@@ -32,7 +32,13 @@ from ..structures.text_schemas import (
     PhonemeResponse,
     PronunciationUpdateRequest,
 )
-from .openai_compatible import process_and_validate_voices, stream_audio_chunks
+from . import openai_compatible
+from .openai_compatible import (
+    process_and_validate_voices,
+    stream_audio_chunks,
+    SpeechBaseUpdate,
+    SpeechAdvancedUpdate,
+)
 
 router = APIRouter(tags=["text processing"])
 
@@ -423,20 +429,22 @@ async def create_captioned_speech(
                 "type": "server_error",
             },
         )
-    except Exception as e:
-        # Handle unexpected errors
-        logger.error(f"Unexpected error in captioned speech generation: {str(e)}")
 
-        try:
-            writer.close()
-        except:
-            pass
 
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "processing_error",
-                "message": str(e),
-                "type": "server_error",
-            },
-        )
+@router.post("/dev/speech/config/base")
+async def dev_update_speech_base(config: SpeechBaseUpdate):
+    """Update base speech configuration (model, voice, speed)."""
+    update = config.model_dump(exclude_none=True)
+    prev_model = openai_compatible.speech_config.model
+    openai_compatible.speech_config = openai_compatible.speech_config.model_copy(update=update)
+    if "model" in update and update["model"] != prev_model:
+        await openai_compatible._reinitialize_model()
+    return {"status": "updated", "config": openai_compatible.speech_config.model_dump()}
+
+
+@router.post("/dev/speech/config/advanced")
+async def dev_update_speech_advanced(config: SpeechAdvancedUpdate):
+    """Update advanced speech configuration."""
+    update = config.model_dump(exclude_none=True)
+    openai_compatible.speech_config = openai_compatible.speech_config.model_copy(update=update)
+    return {"status": "updated", "config": openai_compatible.speech_config.model_dump()}

--- a/api/tests/test_speech_config_endpoints.py
+++ b/api/tests/test_speech_config_endpoints.py
@@ -1,0 +1,66 @@
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from api.src.main import app
+from api.src.routers import openai_compatible
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    openai_compatible.speech_config = openai_compatible.SpeechConfig()
+    yield
+    openai_compatible.speech_config = openai_compatible.SpeechConfig()
+
+
+@pytest.fixture
+def mock_tts_service():
+    with patch("api.src.routers.openai_compatible.get_tts_service") as mock_get:
+        service = AsyncMock()
+        service.generate_audio.return_value = openai_compatible.AudioChunk(
+            np.zeros(100, np.int16)
+        )
+        async def mock_stream(*args, **kwargs):
+            if False:
+                yield b""
+        service.generate_audio_stream = mock_stream
+        service.list_voices.return_value = ["af_heart", "new_voice"]
+        mock_get.return_value = service
+        mock_get.side_effect = None
+        yield service
+
+
+def test_update_base_config_affects_defaults(mock_tts_service):
+    resp = client.post(
+        "/dev/speech/config/base",
+        json={"voice": "new_voice", "speed": 1.5},
+    )
+    assert resp.status_code == 200
+
+    client.post(
+        "/v1/audio/speech",
+        json={"model": "kokoro", "input": "hi", "stream": False},
+    )
+    mock_tts_service.generate_audio.assert_called()
+    kwargs = mock_tts_service.generate_audio.call_args[1]
+    assert kwargs["voice"] == "new_voice"
+    assert kwargs["speed"] == 1.5
+
+
+def test_update_advanced_config_affects_stream(mock_tts_service):
+    resp = client.post(
+        "/dev/speech/config/advanced",
+        json={"stream": False, "response_format": "mp3"},
+    )
+    assert resp.status_code == 200
+
+    client.post(
+        "/v1/audio/speech",
+        json={"model": "kokoro", "input": "hello", "stream": False},
+    )
+    mock_tts_service.generate_audio.assert_called_once()
+


### PR DESCRIPTION
## Summary
- move speech configuration endpoints from openai router to dev router
- update speech_config modifications to affect openai router defaults
- adjust tests for new /dev paths

## Testing
- `pytest api/tests/test_speech_config_endpoints.py::test_update_base_config_affects_defaults -q`
- `pytest -q` *(fails: FileNotFoundError in kokoro_v1 tests)*

------
https://chatgpt.com/codex/tasks/task_b_685d8adc80e8832282a87a3eb6f9bfce